### PR TITLE
Update Contributors.md

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -13,6 +13,7 @@
 - [Jongie Oaquiera] (https://github.com/joaquiera)
 - Samantha Milliga
 - Kalp Vyas
+- [Joshua Retallick](https://github.com/joshuaretallick)
 - Siddhanth Verma
 - Patrick O'Mahony
 - Govind Saju


### PR DESCRIPTION
Added name and git profile as link as per the rest of the people in the doc.
Is it preferred that we dont link it like this and just put
Joshua Retallick www.github.com/joshuaretallick ?